### PR TITLE
Do not Remove Open Class until Completely Closed

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ddm-menu",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "authors": [
     "Joshua Stoutenburg <jstoutenburg@deseretdigital.com>"
   ],

--- a/example/menu.css
+++ b/example/menu.css
@@ -89,16 +89,16 @@ body,
   display: none;
 }
 
+.ddm-menu--open {
+  display: block;
+}
+
 .ddm-menu__inner {
   min-height: 101%;
 }
 
 .ddm-menu--right {
   left: 100%;
-}
-
-.ddm-menu--open {
-  display: block;
 }
 
 .ddm-menu-container--open .ddm-menu-container__overlay,

--- a/example/menu.js
+++ b/example/menu.js
@@ -190,8 +190,17 @@ ddm.menu = (function ($) {
     });
 
     $element.on('close.ddm.menu', function () {
-      $element.removeClass('ddm-menu--open');
       container.close(containerClass);
+
+      if (!helpers.styleSupported('transition')) {
+        $element.removeClass('ddm-menu--open');
+      }
+
+      var transitionEnd = helpers.transitionEnd('ddm.menu.containerClose');
+      $container.on(transitionEnd, function (event) {
+        $element.removeClass('ddm-menu--open');
+        $container.off(transitionEnd);
+      });
     });
 
     $element.on('toggle.ddm.menu', function () {

--- a/src/menu.css
+++ b/src/menu.css
@@ -89,16 +89,16 @@ body,
   display: none;
 }
 
+.ddm-menu--open {
+  display: block;
+}
+
 .ddm-menu__inner {
   min-height: 101%;
 }
 
 .ddm-menu--right {
   left: 100%;
-}
-
-.ddm-menu--open {
-  display: block;
 }
 
 .ddm-menu-container--open .ddm-menu-container__overlay,

--- a/src/menu.js
+++ b/src/menu.js
@@ -190,8 +190,17 @@ ddm.menu = (function ($) {
     });
 
     $element.on('close.ddm.menu', function () {
-      $element.removeClass('ddm-menu--open');
       container.close(containerClass);
+
+      if (!helpers.styleSupported('transition')) {
+        $element.removeClass('ddm-menu--open');
+      }
+
+      var transitionEnd = helpers.transitionEnd('ddm.menu.containerClose');
+      $container.on(transitionEnd, function (event) {
+        $element.removeClass('ddm-menu--open');
+        $container.off(transitionEnd);
+      });
     });
 
     $element.on('toggle.ddm.menu', function () {


### PR DESCRIPTION
We were removing the ddm-menu--open class too soon so when the menu
closed, there was a display of white-space before the transition
finished.

Delay the removal of the ddm-menu--open class until the menu is
completely closed by listening to transition-end events.
