### PR TITLE
Only Close in Teardown if Open

### DIFF
--- a/example/menu.js
+++ b/example/menu.js
@@ -218,7 +218,9 @@ ddm.menu = (function ($) {
     });
 
     $element.on('teardown.ddm.menu', function () {
-      $element.trigger('close.ddm.menu');
+      if (menu.isOpen()) {
+        $element.trigger('close.ddm.menu');
+      }
       $element.removeClass('ddm-menu ddm-menu--right');
       $element.off('.ddm.menu');
       $.each(toggles, function (index, $toggle) {

--- a/src/menu.js
+++ b/src/menu.js
@@ -218,7 +218,9 @@ ddm.menu = (function ($) {
     });
 
     $element.on('teardown.ddm.menu', function () {
-      $element.trigger('close.ddm.menu');
+      if (menu.isOpen()) {
+        $element.trigger('close.ddm.menu');
+      }
       $element.removeClass('ddm-menu ddm-menu--right');
       $element.off('.ddm.menu');
       $.each(toggles, function (index, $toggle) {


### PR DESCRIPTION
We only want to tell the menu to close if it is open. Menus share the container element and closing a menu that isn't really open will cause classes to be erroneously removed from the container element when there might be another menu still needing them there.
