### PR TITLE
Touchmove Instead of Touchstart

### DIFF
--- a/example/menu.js
+++ b/example/menu.js
@@ -63,7 +63,7 @@ ddm.menu = (function ($) {
       });
 
       // for touch devices
-      $element.on('touchstart.scroll-isolate' + eventNamespace, function(event) {
+      $element.on('touchmove.scroll-isolate' + eventNamespace, function(event) {
         var el = this;
 
         // nothing to scroll

--- a/src/menu.js
+++ b/src/menu.js
@@ -63,7 +63,7 @@ ddm.menu = (function ($) {
       });
 
       // for touch devices
-      $element.on('touchstart.scroll-isolate' + eventNamespace, function(event) {
+      $element.on('touchmove.scroll-isolate' + eventNamespace, function(event) {
         var el = this;
 
         // nothing to scroll


### PR DESCRIPTION
When there is not enough menu content to scroll, all clicks are being
cancelled because we are listening to touchstart and preventing default
event behavior, which is to eventually trigger a click event.

Listen to touchmove instead so that touchstart can do it's job unhindered.