### PR TITLE
Fixes Scrolling in Menu for Android 4.0.4

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -119,6 +119,16 @@
               <li>Item 8</li>
               <li>Item 9</li>
               <li>Item 10</li>
+              <li>Item 11</li>
+              <li>Item 12</li>
+              <li>Item 13</li>
+              <li>Item 14</li>
+              <li>Item 15</li>
+              <li>Item 16</li>
+              <li>Item 17</li>
+              <li>Item 18</li>
+              <li>Item 19</li>
+              <li>Item 20</li>
             </ul>
           </div>
         </div>

--- a/example/menu.css
+++ b/example/menu.css
@@ -69,11 +69,3 @@
   display: block;
   left: 0;
 }
-
-/*body*/.ddm-menu-scroll-hack {
-  margin: 0 100% 0 0;
-}
-
-/*body*/.ddm-menu-scroll-hack .ddm-menu-container__content {
-  position: fixed;
-}

--- a/example/menu.css
+++ b/example/menu.css
@@ -6,18 +6,17 @@
 
 .ddm-menu-container__content {
   width: 100%;
-  position: relative;
-  left: 0;
-  -webkit-transition: left 0.3s;
-  transition: left 0.3s;
+  margin-left: 0;
+  -webkit-transition: margin-left 0.3s;
+  transition: margin-left 0.3s;
 }
 
 .ddm-menu-container--open-left .ddm-menu-container__content {
-  left: 85%;
+  margin-left: 85%;
 }
 
 .ddm-menu-container--open-right .ddm-menu-container__content {
-  left: -85%;
+  margin-left: -85%;
 }
 
 .ddm-menu {
@@ -69,3 +68,4 @@
   display: block;
   left: 0;
 }
+

--- a/example/menu.css
+++ b/example/menu.css
@@ -69,3 +69,11 @@
   display: block;
   left: 0;
 }
+
+/*body*/.ddm-menu-scroll-hack {
+  margin: 0 100% 0 0;
+}
+
+/*body*/.ddm-menu-scroll-hack .ddm-menu-container__content {
+  position: fixed;
+}

--- a/example/menu.js
+++ b/example/menu.js
@@ -153,20 +153,6 @@ ddm.menu = (function ($) {
     };
 
 
-    var hack = {
-      do: function () {
-        console.log('hack.do');
-        $(document).trigger('resize');
-        $('body').addClass('ddm-menu-scroll-hack');
-      },
-      undo: function () {
-        console.log('hack.undo');
-        $('body').removeClass('ddm-menu-scroll-hack');
-      }
-    };
-
-
-
     /*= events =*/
     scroll.isolate($element.get(0));
 
@@ -175,13 +161,11 @@ ddm.menu = (function ($) {
       $element.addClass('ddm-menu--open');
       $element.focus();
       $container.addClass(containerClass);
-      hack.do();
     });
 
     $element.on('close.ddm-menu', function () {
       $container.removeClass(containerClass);
       $element.removeClass('ddm-menu--open');
-      hack.undo();
     });
 
     $element.on('toggle.ddm-menu', function () {

--- a/example/menu.js
+++ b/example/menu.js
@@ -153,6 +153,19 @@ ddm.menu = (function ($) {
     };
 
 
+    var hack = {
+      do: function () {
+        console.log('hack.do');
+        $(document).trigger('resize');
+        $('body').addClass('ddm-menu-scroll-hack');
+      },
+      undo: function () {
+        console.log('hack.undo');
+        $('body').removeClass('ddm-menu-scroll-hack');
+      }
+    };
+
+
 
     /*= events =*/
     scroll.isolate($element.get(0));
@@ -162,11 +175,13 @@ ddm.menu = (function ($) {
       $element.addClass('ddm-menu--open');
       $element.focus();
       $container.addClass(containerClass);
+      hack.do();
     });
 
     $element.on('close.ddm-menu', function () {
       $container.removeClass(containerClass);
       $element.removeClass('ddm-menu--open');
+      hack.undo();
     });
 
     $element.on('toggle.ddm-menu', function () {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ddm-menu",
   "description": "Creates an offscreen menu. See the [example](http://ui.deseretdigital.com/ddm-menu/) for working examples.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "license": "MIT",
   "private": true,
   "main": "src/menu.js",

--- a/src/menu.css
+++ b/src/menu.css
@@ -69,11 +69,3 @@
   display: block;
   left: 0;
 }
-
-/*body*/.ddm-menu-scroll-hack {
-  margin: 0 100% 0 0;
-}
-
-/*body*/.ddm-menu-scroll-hack .ddm-menu-container__content {
-  position: fixed;
-}

--- a/src/menu.css
+++ b/src/menu.css
@@ -6,18 +6,17 @@
 
 .ddm-menu-container__content {
   width: 100%;
-  position: relative;
-  left: 0;
-  -webkit-transition: left 0.3s;
-  transition: left 0.3s;
+  margin-left: 0;
+  -webkit-transition: margin-left 0.3s;
+  transition: margin-left 0.3s;
 }
 
 .ddm-menu-container--open-left .ddm-menu-container__content {
-  left: 85%;
+  margin-left: 85%;
 }
 
 .ddm-menu-container--open-right .ddm-menu-container__content {
-  left: -85%;
+  margin-left: -85%;
 }
 
 .ddm-menu {
@@ -69,3 +68,4 @@
   display: block;
   left: 0;
 }
+

--- a/src/menu.css
+++ b/src/menu.css
@@ -69,3 +69,11 @@
   display: block;
   left: 0;
 }
+
+/*body*/.ddm-menu-scroll-hack {
+  margin: 0 100% 0 0;
+}
+
+/*body*/.ddm-menu-scroll-hack .ddm-menu-container__content {
+  position: fixed;
+}

--- a/src/menu.js
+++ b/src/menu.js
@@ -153,20 +153,6 @@ ddm.menu = (function ($) {
     };
 
 
-    var hack = {
-      do: function () {
-        console.log('hack.do');
-        $(document).trigger('resize');
-        $('body').addClass('ddm-menu-scroll-hack');
-      },
-      undo: function () {
-        console.log('hack.undo');
-        $('body').removeClass('ddm-menu-scroll-hack');
-      }
-    };
-
-
-
     /*= events =*/
     scroll.isolate($element.get(0));
 
@@ -175,13 +161,11 @@ ddm.menu = (function ($) {
       $element.addClass('ddm-menu--open');
       $element.focus();
       $container.addClass(containerClass);
-      hack.do();
     });
 
     $element.on('close.ddm-menu', function () {
       $container.removeClass(containerClass);
       $element.removeClass('ddm-menu--open');
-      hack.undo();
     });
 
     $element.on('toggle.ddm-menu', function () {

--- a/src/menu.js
+++ b/src/menu.js
@@ -153,6 +153,19 @@ ddm.menu = (function ($) {
     };
 
 
+    var hack = {
+      do: function () {
+        console.log('hack.do');
+        $(document).trigger('resize');
+        $('body').addClass('ddm-menu-scroll-hack');
+      },
+      undo: function () {
+        console.log('hack.undo');
+        $('body').removeClass('ddm-menu-scroll-hack');
+      }
+    };
+
+
 
     /*= events =*/
     scroll.isolate($element.get(0));
@@ -162,11 +175,13 @@ ddm.menu = (function ($) {
       $element.addClass('ddm-menu--open');
       $element.focus();
       $container.addClass(containerClass);
+      hack.do();
     });
 
     $element.on('close.ddm-menu', function () {
       $container.removeClass(containerClass);
       $element.removeClass('ddm-menu--open');
+      hack.undo();
     });
 
     $element.on('toggle.ddm-menu', function () {


### PR DESCRIPTION
We observed that Android 4.0.4 doesn't handle fixed position elements inside relative position elements correctly. So we use margin instead of relative positioning to move the content element when the menu opens.