### PR TITLE
Android 4.0.4 Content Scroll Hack

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -248,33 +248,27 @@
       </div>
 
       <h3>Dummy Content</h3>
-
-      <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus congue porta felis non fringilla. Etiam nisl turpis, volutpat ut ipsum id, semper ornare velit. Aliquam non lectus rhoncus, laoreet nisl eget, elementum nisi. Nullam diam ligula, faucibus quis orci rhoncus, blandit facilisis odio. Curabitur iaculis convallis felis ut iaculis. Etiam ut orci ullamcorper ligula elementum elementum vel at odio. Pellentesque feugiat lorem leo, non interdum nisl tristique nec. Suspendisse iaculis urna non convallis
-      </p>
-
-      <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus congue porta felis non fringilla. Etiam nisl turpis, volutpat ut ipsum id, semper ornare velit. Aliquam non lectus rhoncus, laoreet nisl eget, elementum nisi. Nullam diam ligula, faucibus quis orci rhoncus, blandit facilisis odio. Curabitur iaculis convallis felis ut iaculis. Etiam ut orci ullamcorper ligula elementum elementum vel at odio. Pellentesque feugiat lorem leo, non interdum nisl tristique nec. Suspendisse iaculis urna non convallis
-      </p>
-
-      <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus congue porta felis non fringilla. Etiam nisl turpis, volutpat ut ipsum id, semper ornare velit. Aliquam non lectus rhoncus, laoreet nisl eget, elementum nisi. Nullam diam ligula, faucibus quis orci rhoncus, blandit facilisis odio. Curabitur iaculis convallis felis ut iaculis. Etiam ut orci ullamcorper ligula elementum elementum vel at odio. Pellentesque feugiat lorem leo, non interdum nisl tristique nec. Suspendisse iaculis urna non convallis
-      </p>
-
-      <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus congue porta felis non fringilla. Etiam nisl turpis, volutpat ut ipsum id, semper ornare velit. Aliquam non lectus rhoncus, laoreet nisl eget, elementum nisi. Nullam diam ligula, faucibus quis orci rhoncus, blandit facilisis odio. Curabitur iaculis convallis felis ut iaculis. Etiam ut orci ullamcorper ligula elementum elementum vel at odio. Pellentesque feugiat lorem leo, non interdum nisl tristique nec. Suspendisse iaculis urna non convallis
-      </p>
-
-      <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus congue porta felis non fringilla. Etiam nisl turpis, volutpat ut ipsum id, semper ornare velit. Aliquam non lectus rhoncus, laoreet nisl eget, elementum nisi. Nullam diam ligula, faucibus quis orci rhoncus, blandit facilisis odio. Curabitur iaculis convallis felis ut iaculis. Etiam ut orci ullamcorper ligula elementum elementum vel at odio. Pellentesque feugiat lorem leo, non interdum nisl tristique nec. Suspendisse iaculis urna non convallis
-      </p>
-
-      <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus congue porta felis non fringilla. Etiam nisl turpis, volutpat ut ipsum id, semper ornare velit. Aliquam non lectus rhoncus, laoreet nisl eget, elementum nisi. Nullam diam ligula, faucibus quis orci rhoncus, blandit facilisis odio. Curabitur iaculis convallis felis ut iaculis. Etiam ut orci ullamcorper ligula elementum elementum vel at odio. Pellentesque feugiat lorem leo, non interdum nisl tristique nec. Suspendisse iaculis urna non convallis
-      </p>
-
+      <div id="dummyContent">
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus congue porta felis non fringilla. Etiam nisl turpis, volutpat ut ipsum id, semper ornare velit. Aliquam non lectus rhoncus, laoreet nisl eget, elementum nisi. Nullam diam ligula, faucibus quis orci rhoncus, blandit facilisis odio. Curabitur iaculis convallis felis ut iaculis. Etiam ut orci ullamcorper ligula elementum elementum vel at odio. Pellentesque feugiat lorem leo, non interdum nisl tristique nec. Suspendisse iaculis urna non convallis</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus congue porta felis non fringilla. Etiam nisl turpis, volutpat ut ipsum id, semper ornare velit. Aliquam non lectus rhoncus, laoreet nisl eget, elementum nisi. Nullam diam ligula, faucibus quis orci rhoncus, blandit facilisis odio. Curabitur iaculis convallis felis ut iaculis. Etiam ut orci ullamcorper ligula elementum elementum vel at odio. Pellentesque feugiat lorem leo, non interdum nisl tristique nec. Suspendisse iaculis urna non convallis</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus congue porta felis non fringilla. Etiam nisl turpis, volutpat ut ipsum id, semper ornare velit. Aliquam non lectus rhoncus, laoreet nisl eget, elementum nisi. Nullam diam ligula, faucibus quis orci rhoncus, blandit facilisis odio. Curabitur iaculis convallis felis ut iaculis. Etiam ut orci ullamcorper ligula elementum elementum vel at odio. Pellentesque feugiat lorem leo, non interdum nisl tristique nec. Suspendisse iaculis urna non convallis</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus congue porta felis non fringilla. Etiam nisl turpis, volutpat ut ipsum id, semper ornare velit. Aliquam non lectus rhoncus, laoreet nisl eget, elementum nisi. Nullam diam ligula, faucibus quis orci rhoncus, blandit facilisis odio. Curabitur iaculis convallis felis ut iaculis. Etiam ut orci ullamcorper ligula elementum elementum vel at odio. Pellentesque feugiat lorem leo, non interdum nisl tristique nec. Suspendisse iaculis urna non convallis</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus congue porta felis non fringilla. Etiam nisl turpis, volutpat ut ipsum id, semper ornare velit. Aliquam non lectus rhoncus, laoreet nisl eget, elementum nisi. Nullam diam ligula, faucibus quis orci rhoncus, blandit facilisis odio. Curabitur iaculis convallis felis ut iaculis. Etiam ut orci ullamcorper ligula elementum elementum vel at odio. Pellentesque feugiat lorem leo, non interdum nisl tristique nec. Suspendisse iaculis urna non convallis</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus congue porta felis non fringilla. Etiam nisl turpis, volutpat ut ipsum id, semper ornare velit. Aliquam non lectus rhoncus, laoreet nisl eget, elementum nisi. Nullam diam ligula, faucibus quis orci rhoncus, blandit facilisis odio. Curabitur iaculis convallis felis ut iaculis. Etiam ut orci ullamcorper ligula elementum elementum vel at odio. Pellentesque feugiat lorem leo, non interdum nisl tristique nec. Suspendisse iaculis urna non convallis</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus congue porta felis non fringilla. Etiam nisl turpis, volutpat ut ipsum id, semper ornare velit. Aliquam non lectus rhoncus, laoreet nisl eget, elementum nisi. Nullam diam ligula, faucibus quis orci rhoncus, blandit facilisis odio. Curabitur iaculis convallis felis ut iaculis. Etiam ut orci ullamcorper ligula elementum elementum vel at odio. Pellentesque feugiat lorem leo, non interdum nisl tristique nec. Suspendisse iaculis urna non convallis</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus congue porta felis non fringilla. Etiam nisl turpis, volutpat ut ipsum id, semper ornare velit. Aliquam non lectus rhoncus, laoreet nisl eget, elementum nisi. Nullam diam ligula, faucibus quis orci rhoncus, blandit facilisis odio. Curabitur iaculis convallis felis ut iaculis. Etiam ut orci ullamcorper ligula elementum elementum vel at odio. Pellentesque feugiat lorem leo, non interdum nisl tristique nec. Suspendisse iaculis urna non convallis</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus congue porta felis non fringilla. Etiam nisl turpis, volutpat ut ipsum id, semper ornare velit. Aliquam non lectus rhoncus, laoreet nisl eget, elementum nisi. Nullam diam ligula, faucibus quis orci rhoncus, blandit facilisis odio. Curabitur iaculis convallis felis ut iaculis. Etiam ut orci ullamcorper ligula elementum elementum vel at odio. Pellentesque feugiat lorem leo, non interdum nisl tristique nec. Suspendisse iaculis urna non convallis</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus congue porta felis non fringilla. Etiam nisl turpis, volutpat ut ipsum id, semper ornare velit. Aliquam non lectus rhoncus, laoreet nisl eget, elementum nisi. Nullam diam ligula, faucibus quis orci rhoncus, blandit facilisis odio. Curabitur iaculis convallis felis ut iaculis. Etiam ut orci ullamcorper ligula elementum elementum vel at odio. Pellentesque feugiat lorem leo, non interdum nisl tristique nec. Suspendisse iaculis urna non convallis</p>
+      </div>
+      <button id="loadMoreDummyContent">Load More</button>
+      <script>
+        $(function () {
+          $('#loadMoreDummyContent').on('click', function () {
+            $('#dummyContent p').slice(0,10).clone().appendTo('#dummyContent');
+          });
+        });
+      </script>
       <p>Fin</p>
-
     </div>
 
   </div>

--- a/example/menu.css
+++ b/example/menu.css
@@ -69,3 +69,19 @@
   left: 0;
 }
 
+/*
+ * Android 4.0.4 Content Scroll Hack
+ *
+ * For some reason, content extends beyond scrollable area when content is
+ * added dynamically to the page due to the menu having `position: fixed`.
+ * We don't really understand it. But we've proven that `position: fixed` is
+ * the problem by process of elimination (removing styles until the issue
+ * disappears). So our hackish workaround is to toggle `position: fixed`
+ * rule when the content height changes. Instead of requiring ddm-menu users
+ * to call another method for this silly issue, we use an interval to
+ * monitor content height.
+ */
+.ddm-menu--android-content-scroll-hack {
+  position: static;
+  display: none;
+}

--- a/example/menu.css
+++ b/example/menu.css
@@ -81,7 +81,7 @@
  * to call another method for this silly issue, we use an interval to
  * monitor content height.
  */
-.ddm-menu--android-content-scroll-hack {
+/*body*/.ddm-menu-android-content-scroll-hack .ddm-menu {
   position: static;
   display: none;
 }

--- a/example/menu.js
+++ b/example/menu.js
@@ -120,9 +120,10 @@ ddm.menu = (function ($) {
   var androidContentScrollHack = {
     _interval: null,
     _documentHeight: null,
+    _browserMatch: null,
 
     enable: function () {
-      if (this._interval !== null) { return; }
+      if (!this._isBrowserMatch() || this._interval !== null) { return; }
 
       this._interval = setInterval(function () {
         var documentHeight = $(document).height();
@@ -139,23 +140,51 @@ ddm.menu = (function ($) {
     },
 
     disable: function () {
+      if (this._interval === null) { return; }
       clearInterval(this._interval);
       this._interval = null;
+    },
+
+    _isBrowserMatch: function () {
+      console.log('_isBrowserMatch');
+      if (this._browserMatch !== null) {
+        return this._browserMatch;
+      }
+
+      var uaPatterns = [
+        /android 4.0.4/
+      ];
+
+      var match = false;
+      var ua = navigator.userAgent.toLowerCase();
+      for (var key in uaPatterns) {
+        if (uaPatterns[key].test(ua)) {
+          match = true;
+          break;
+        }
+      }
+
+      this._browserMatch = match;
     }
   };
 
 
   var Menu = function ($element, $container) {
 
+    // private variables
+    var toggles = [];
+    var menu = this;
+
+    // ensure menu has ddm-menu class
     $element.addClass('ddm-menu');
 
-    var menu = this;
+    // determine container "open" class
     var containerClass = 'ddm-menu-container--open-left';
     if ($element.hasClass('ddm-menu--right')) {
       containerClass = 'ddm-menu-container--open-right';
     }
-    var toggles = [];
 
+    // enable content scroll hack
     androidContentScrollHack.enable();
 
 

--- a/example/menu.js
+++ b/example/menu.js
@@ -106,52 +106,55 @@ ddm.menu = (function ($) {
   });
 
 
+  // Android 4.0.4 Content Scroll Hack
+  //
+  // For some reason, content extends beyond scrollable area when content is
+  // added dynamically to the page due to the menu having `position: fixed`.
+  // We don't really understand it. But we've proven that `position: fixed` is
+  // the problem by process of elimination (removing styles until the issue
+  // disappears). So our hackish workaround is to toggle `position: fixed`
+  // rule when the content height changes. Instead of requiring ddm-menu users
+  // to call another method for this silly issue, we use an interval to
+  // monitor content height.
+
+  var androidContentScrollHack = {
+    _interval: null,
+    _documentHeight: null,
+
+    enable: function () {
+      if (this._interval !== null) { return; }
+
+      this._interval = setInterval(function () {
+        var documentHeight = $(document).height();
+        var change = documentHeight !== this._documentHeight;
+
+        if (change) {
+          $('body').addClass('ddm-menu-android-content-scroll-hack');
+          setTimeout(function () {
+            $('body').removeClass('ddm-menu-android-content-scroll-hack');
+          }, 10);
+          this._documentHeight = documentHeight;
+        }
+      }.bind(this), 1000);
+    },
+
+    disable: function () {
+      clearInterval(this._interval);
+      this._interval = null;
+    }
+  };
+
 
   var Menu = function ($element, $container) {
 
     $element.addClass('ddm-menu');
+
     var menu = this;
     var containerClass = 'ddm-menu-container--open-left';
     if ($element.hasClass('ddm-menu--right')) {
       containerClass = 'ddm-menu-container--open-right';
     }
     var toggles = [];
-
-
-    // Android 4.0.4 Content Scroll Hack
-    //
-    // For some reason, content extends beyond scrollable area when content is
-    // added dynamically to the page due to the menu having `position: fixed`.
-    // We don't really understand it. But we've proven that `position: fixed` is
-    // the problem by process of elimination (removing styles until the issue
-    // disappears). So our hackish workaround is to toggle `position: fixed`
-    // rule when the content height changes. Instead of requiring ddm-menu users
-    // to call another method for this silly issue, we use an interval to
-    // monitor content height.
-
-    var androidContentScrollHack = {
-      _interval: null,
-      _contentHeight: null,
-
-      enable: function () {
-        this._interval = setInterval(function () {
-          var contentHeight = $('.ddm-menu-container__content').outerHeight(true);
-          var change = contentHeight !== this._contentHeight;
-          if (change) {
-            $element.removeClass('ddm-menu--android-content-scroll-hack');
-            setTimeout(function () {
-              $element.addClass('ddm-menu--android-content-scroll-hack');
-            }, 0);
-            this._contentHeight = contentHeight;
-          }
-        }, 1000);
-      },
-
-      disable: function () {
-        clearInterval(this._interval);
-        this._interval = null;
-      }
-    };
 
     androidContentScrollHack.enable();
 

--- a/example/menu.js
+++ b/example/menu.js
@@ -1,7 +1,6 @@
 var ddm = ddm || {};
 ddm.menu = (function ($) {
 
-
   // self documenting scroll helpers
   var scroll = {
     atTop: function (el, delta) {
@@ -119,6 +118,43 @@ ddm.menu = (function ($) {
     var toggles = [];
 
 
+    // Android 4.0.4 Content Scroll Hack
+    //
+    // For some reason, content extends beyond scrollable area when content is
+    // added dynamically to the page due to the menu having `position: fixed`.
+    // We don't really understand it. But we've proven that `position: fixed` is
+    // the problem by process of elimination (removing styles until the issue
+    // disappears). So our hackish workaround is to toggle `position: fixed`
+    // rule when the content height changes. Instead of requiring ddm-menu users
+    // to call another method for this silly issue, we use an interval to
+    // monitor content height.
+
+    var androidContentScrollHack = {
+      _interval: null,
+      _contentHeight: null,
+
+      enable: function () {
+        this._interval = setInterval(function () {
+          var contentHeight = $('.ddm-menu-container__content').outerHeight(true);
+          var change = contentHeight !== this._contentHeight;
+          if (change) {
+            $element.removeClass('ddm-menu--android-content-scroll-hack');
+            setTimeout(function () {
+              $element.addClass('ddm-menu--android-content-scroll-hack');
+            }, 0);
+            this._contentHeight = contentHeight;
+          }
+        }, 1000);
+      },
+
+      disable: function () {
+        clearInterval(this._interval);
+        this._interval = null;
+      }
+    };
+
+    androidContentScrollHack.enable();
+
 
     /* public methods */
 
@@ -186,6 +222,7 @@ ddm.menu = (function ($) {
         $toggle.off('.ddm-menu');
       });
       $element.removeData('ddm-menu-api');
+      androidContentScrollHack.disable();
     });
 
   };

--- a/example/menu.js
+++ b/example/menu.js
@@ -135,7 +135,7 @@ ddm.menu = (function ($) {
           }, 10);
           this._documentHeight = documentHeight;
         }
-      }.bind(this), 1000);
+      }.bind(this), 300);
     },
 
     disable: function () {

--- a/example/menu.js
+++ b/example/menu.js
@@ -146,7 +146,6 @@ ddm.menu = (function ($) {
     },
 
     _isBrowserMatch: function () {
-      console.log('_isBrowserMatch');
       if (this._browserMatch !== null) {
         return this._browserMatch;
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ddm-menu",
   "description": "Creates an offscreen menu. See the [example](http://ui.deseretdigital.com/ddm-menu/) for working examples.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "license": "MIT",
   "private": true,
   "main": "src/menu.js",

--- a/src/menu.css
+++ b/src/menu.css
@@ -69,3 +69,19 @@
   left: 0;
 }
 
+/*
+ * Android 4.0.4 Content Scroll Hack
+ *
+ * For some reason, content extends beyond scrollable area when content is
+ * added dynamically to the page due to the menu having `position: fixed`.
+ * We don't really understand it. But we've proven that `position: fixed` is
+ * the problem by process of elimination (removing styles until the issue
+ * disappears). So our hackish workaround is to toggle `position: fixed`
+ * rule when the content height changes. Instead of requiring ddm-menu users
+ * to call another method for this silly issue, we use an interval to
+ * monitor content height.
+ */
+.ddm-menu--android-content-scroll-hack {
+  position: static;
+  display: none;
+}

--- a/src/menu.css
+++ b/src/menu.css
@@ -81,7 +81,7 @@
  * to call another method for this silly issue, we use an interval to
  * monitor content height.
  */
-.ddm-menu--android-content-scroll-hack {
+/*body*/.ddm-menu-android-content-scroll-hack .ddm-menu {
   position: static;
   display: none;
 }

--- a/src/menu.js
+++ b/src/menu.js
@@ -120,9 +120,10 @@ ddm.menu = (function ($) {
   var androidContentScrollHack = {
     _interval: null,
     _documentHeight: null,
+    _browserMatch: null,
 
     enable: function () {
-      if (this._interval !== null) { return; }
+      if (!this._isBrowserMatch() || this._interval !== null) { return; }
 
       this._interval = setInterval(function () {
         var documentHeight = $(document).height();
@@ -139,23 +140,51 @@ ddm.menu = (function ($) {
     },
 
     disable: function () {
+      if (this._interval === null) { return; }
       clearInterval(this._interval);
       this._interval = null;
+    },
+
+    _isBrowserMatch: function () {
+      console.log('_isBrowserMatch');
+      if (this._browserMatch !== null) {
+        return this._browserMatch;
+      }
+
+      var uaPatterns = [
+        /android 4.0.4/
+      ];
+
+      var match = false;
+      var ua = navigator.userAgent.toLowerCase();
+      for (var key in uaPatterns) {
+        if (uaPatterns[key].test(ua)) {
+          match = true;
+          break;
+        }
+      }
+
+      this._browserMatch = match;
     }
   };
 
 
   var Menu = function ($element, $container) {
 
+    // private variables
+    var toggles = [];
+    var menu = this;
+
+    // ensure menu has ddm-menu class
     $element.addClass('ddm-menu');
 
-    var menu = this;
+    // determine container "open" class
     var containerClass = 'ddm-menu-container--open-left';
     if ($element.hasClass('ddm-menu--right')) {
       containerClass = 'ddm-menu-container--open-right';
     }
-    var toggles = [];
 
+    // enable content scroll hack
     androidContentScrollHack.enable();
 
 

--- a/src/menu.js
+++ b/src/menu.js
@@ -106,52 +106,55 @@ ddm.menu = (function ($) {
   });
 
 
+  // Android 4.0.4 Content Scroll Hack
+  //
+  // For some reason, content extends beyond scrollable area when content is
+  // added dynamically to the page due to the menu having `position: fixed`.
+  // We don't really understand it. But we've proven that `position: fixed` is
+  // the problem by process of elimination (removing styles until the issue
+  // disappears). So our hackish workaround is to toggle `position: fixed`
+  // rule when the content height changes. Instead of requiring ddm-menu users
+  // to call another method for this silly issue, we use an interval to
+  // monitor content height.
+
+  var androidContentScrollHack = {
+    _interval: null,
+    _documentHeight: null,
+
+    enable: function () {
+      if (this._interval !== null) { return; }
+
+      this._interval = setInterval(function () {
+        var documentHeight = $(document).height();
+        var change = documentHeight !== this._documentHeight;
+
+        if (change) {
+          $('body').addClass('ddm-menu-android-content-scroll-hack');
+          setTimeout(function () {
+            $('body').removeClass('ddm-menu-android-content-scroll-hack');
+          }, 10);
+          this._documentHeight = documentHeight;
+        }
+      }.bind(this), 1000);
+    },
+
+    disable: function () {
+      clearInterval(this._interval);
+      this._interval = null;
+    }
+  };
+
 
   var Menu = function ($element, $container) {
 
     $element.addClass('ddm-menu');
+
     var menu = this;
     var containerClass = 'ddm-menu-container--open-left';
     if ($element.hasClass('ddm-menu--right')) {
       containerClass = 'ddm-menu-container--open-right';
     }
     var toggles = [];
-
-
-    // Android 4.0.4 Content Scroll Hack
-    //
-    // For some reason, content extends beyond scrollable area when content is
-    // added dynamically to the page due to the menu having `position: fixed`.
-    // We don't really understand it. But we've proven that `position: fixed` is
-    // the problem by process of elimination (removing styles until the issue
-    // disappears). So our hackish workaround is to toggle `position: fixed`
-    // rule when the content height changes. Instead of requiring ddm-menu users
-    // to call another method for this silly issue, we use an interval to
-    // monitor content height.
-
-    var androidContentScrollHack = {
-      _interval: null,
-      _contentHeight: null,
-
-      enable: function () {
-        this._interval = setInterval(function () {
-          var contentHeight = $('.ddm-menu-container__content').outerHeight(true);
-          var change = contentHeight !== this._contentHeight;
-          if (change) {
-            $element.removeClass('ddm-menu--android-content-scroll-hack');
-            setTimeout(function () {
-              $element.addClass('ddm-menu--android-content-scroll-hack');
-            }, 0);
-            this._contentHeight = contentHeight;
-          }
-        }, 1000);
-      },
-
-      disable: function () {
-        clearInterval(this._interval);
-        this._interval = null;
-      }
-    };
 
     androidContentScrollHack.enable();
 

--- a/src/menu.js
+++ b/src/menu.js
@@ -1,7 +1,6 @@
 var ddm = ddm || {};
 ddm.menu = (function ($) {
 
-
   // self documenting scroll helpers
   var scroll = {
     atTop: function (el, delta) {
@@ -119,6 +118,43 @@ ddm.menu = (function ($) {
     var toggles = [];
 
 
+    // Android 4.0.4 Content Scroll Hack
+    //
+    // For some reason, content extends beyond scrollable area when content is
+    // added dynamically to the page due to the menu having `position: fixed`.
+    // We don't really understand it. But we've proven that `position: fixed` is
+    // the problem by process of elimination (removing styles until the issue
+    // disappears). So our hackish workaround is to toggle `position: fixed`
+    // rule when the content height changes. Instead of requiring ddm-menu users
+    // to call another method for this silly issue, we use an interval to
+    // monitor content height.
+
+    var androidContentScrollHack = {
+      _interval: null,
+      _contentHeight: null,
+
+      enable: function () {
+        this._interval = setInterval(function () {
+          var contentHeight = $('.ddm-menu-container__content').outerHeight(true);
+          var change = contentHeight !== this._contentHeight;
+          if (change) {
+            $element.removeClass('ddm-menu--android-content-scroll-hack');
+            setTimeout(function () {
+              $element.addClass('ddm-menu--android-content-scroll-hack');
+            }, 0);
+            this._contentHeight = contentHeight;
+          }
+        }, 1000);
+      },
+
+      disable: function () {
+        clearInterval(this._interval);
+        this._interval = null;
+      }
+    };
+
+    androidContentScrollHack.enable();
+
 
     /* public methods */
 
@@ -186,6 +222,7 @@ ddm.menu = (function ($) {
         $toggle.off('.ddm-menu');
       });
       $element.removeData('ddm-menu-api');
+      androidContentScrollHack.disable();
     });
 
   };

--- a/src/menu.js
+++ b/src/menu.js
@@ -135,7 +135,7 @@ ddm.menu = (function ($) {
           }, 10);
           this._documentHeight = documentHeight;
         }
-      }.bind(this), 1000);
+      }.bind(this), 300);
     },
 
     disable: function () {

--- a/src/menu.js
+++ b/src/menu.js
@@ -146,7 +146,6 @@ ddm.menu = (function ($) {
     },
 
     _isBrowserMatch: function () {
-      console.log('_isBrowserMatch');
       if (this._browserMatch !== null) {
         return this._browserMatch;
       }


### PR DESCRIPTION
For some reason, Android 4.0.4, Default Browser, when there are fixed position elements, and content is added dynamically, leaves some content unreachable by scroll. The `.ddm-menu` elements are `position: fixed`. Toggling `position: fixed` is a workaround for the issue.

Uses an interval to monitor document height, and when a change is detected, add hack class that disables `position: fixed` on `.ddm-menu` elements, then take the class off again.